### PR TITLE
fix: update golang-jwt dependency to v5.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	firebase.google.com/go/v4 v4.18.0
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
# Description
- update the JWT module from version v5.2.1 to v5.2.2