### PR TITLE
Add analytics endpoint with role-based spend breakdowns

### DIFF
--- a/controllers/ExpenseRequestsController.go
+++ b/controllers/ExpenseRequestsController.go
@@ -171,6 +171,48 @@ func (ex *ExpenseRequestsController) GetExpenseRequestsSummary(c echo.Context) e
 	return c.JSON(http.StatusOK, summary)
 }
 
+func (ex *ExpenseRequestsController) GetAnalytics(c echo.Context) error {
+	filters := make(map[string]any)
+
+	if c.QueryParam("start_date") != "" {
+		startDate, err := time.Parse("2006-01-02", c.QueryParam("start_date"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, "Invalid start date")
+		}
+		filters["start_date"] = startDate
+	}
+
+	if c.QueryParam("end_date") != "" {
+		endDate, err := time.Parse("2006-01-02", c.QueryParam("end_date"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, "Invalid end date")
+		}
+		filters["end_date"] = endDate
+	}
+
+	if c.QueryParam("user_id") != "" {
+		userID, err := strconv.Atoi(c.QueryParam("user_id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, "Invalid user ID")
+		}
+		filters["user_id"] = uint(userID)
+	}
+
+	if c.QueryParam("approver_id") != "" {
+		approverID, err := strconv.Atoi(c.QueryParam("approver_id"))
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, "Invalid approver ID")
+		}
+		filters["approver_id"] = uint(approverID)
+	}
+
+	result, err := ex.ExpenseRequestsService.GetAnalytics(filters)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
 // CreateExpenseRequest creates a new expense request
 // @Summary Create a new expense request
 // @Description Create a new expense request

--- a/dtos/AnalyticsDTO.go
+++ b/dtos/AnalyticsDTO.go
@@ -1,0 +1,33 @@
+package dtos
+
+type AnalyticsSpendItem struct {
+	Name   string  `json:"name"`
+	Code   string  `json:"code"`
+	Amount float64 `json:"amount"`
+}
+
+type AnalyticsLeaderboardItem struct {
+	ID     uint    `json:"id"`
+	Name   string  `json:"name"`
+	Team   string  `json:"team"`
+	Amount float64 `json:"amount"`
+	Count  int     `json:"count"`
+}
+
+type AnalyticsActivityItem struct {
+	Kind   string  `json:"kind"`
+	Who    string  `json:"who"`
+	Code   string  `json:"code"`
+	Text   string  `json:"text"`
+	Amount float64 `json:"amount"`
+	When   string  `json:"when"`
+}
+
+type AnalyticsResponse struct {
+	SpendByProject []AnalyticsSpendItem       `json:"spend_by_project"`
+	SpendByGL      []AnalyticsSpendItem       `json:"spend_by_gl"`
+	SpendByPayment []AnalyticsSpendItem       `json:"spend_by_payment"`
+	TopSubmitters  []AnalyticsLeaderboardItem `json:"top_submitters"`
+	TopApprovers   []AnalyticsLeaderboardItem `json:"top_approvers"`
+	RecentActivity []AnalyticsActivityItem    `json:"recent_activity"`
+}

--- a/dtos/ExpenseRequestDTO.go
+++ b/dtos/ExpenseRequestDTO.go
@@ -1,10 +1,16 @@
 package dtos
 
+type DailyBreakdown struct {
+	Approved float64 `json:"approved"`
+	Pending  float64 `json:"pending"`
+	Rejected float64 `json:"rejected"`
+}
+
 type ExpenseRequestSummary struct {
-	Total       int                `json:"total"`
-	Pending     int                `json:"pending"`
-	Approved    int                `json:"approved"`
-	Rejected    int                `json:"rejected"`
-	TotalAmount float64            `json:"total_amount"`
-	DailyTotal  map[string]float64 `json:"daily_totals"`
+	Total       int                       `json:"total"`
+	Pending     int                       `json:"pending"`
+	Approved    int                       `json:"approved"`
+	Rejected    int                       `json:"rejected"`
+	TotalAmount float64                   `json:"total_amount"`
+	DailyTotal  map[string]DailyBreakdown `json:"daily_totals"`
 }

--- a/repositories/ExpenseRequestsRepo.go
+++ b/repositories/ExpenseRequestsRepo.go
@@ -9,6 +9,7 @@ import (
 	"shwetaik-expense-management-api/dtos"
 	"shwetaik-expense-management-api/models"
 	"shwetaik-expense-management-api/utilities"
+	"sort"
 	"strconv"
 	"time"
 
@@ -173,8 +174,8 @@ func (r *ExpenseRequestsRepo) GetExpenseRequestsSummary(filters map[string]any) 
 	}
 
 	if filters["start_date"] != nil && filters["end_date"] != nil {
-		db = db.Where("date_submitted BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
-		summary.DailyTotal = make(map[string]float64)
+		db = db.Where("DATE(date_submitted) BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
+		summary.DailyTotal = make(map[string]dtos.DailyBreakdown)
 	}
 
 	if filters["amount"] != nil {
@@ -195,7 +196,16 @@ func (r *ExpenseRequestsRepo) GetExpenseRequestsSummary(filters map[string]any) 
 
 		if filters["start_date"] != nil && filters["end_date"] != nil {
 			date := expenseRequest.DateSubmitted.Format("2006-01-02")
-			summary.DailyTotal[date] = summary.DailyTotal[date] + expenseRequest.Amount
+			entry := summary.DailyTotal[date]
+			switch expenseRequest.Status {
+			case "approved":
+				entry.Approved += expenseRequest.Amount
+			case "pending":
+				entry.Pending += expenseRequest.Amount
+			case "rejected":
+				entry.Rejected += expenseRequest.Amount
+			}
+			summary.DailyTotal[date] = entry
 		}
 
 	}
@@ -539,4 +549,267 @@ func (r *ExpenseRequestsRepo) DeleteExpenseRequest(id uint) error {
 		return err
 	}
 	return tx.Commit().Error
+}
+
+func (r *ExpenseRequestsRepo) GetAnalytics(filters map[string]any) (dtos.AnalyticsResponse, error) {
+	var result dtos.AnalyticsResponse
+
+	// Build base approved-request scope reusable across sub-queries.
+	baseApproved := func() *gorm.DB {
+		q := r.db.Table("expense_requests er").Where("er.status = 'approved'")
+		if filters["start_date"] != nil && filters["end_date"] != nil {
+			q = q.Where("DATE(er.date_submitted) BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
+		}
+		if filters["user_id"] != nil {
+			q = q.Where("er.user_id = ?", filters["user_id"])
+		}
+		if filters["approver_id"] != nil {
+			q = q.Joins("JOIN expense_approvals _af ON _af.request_id = er.id AND _af.approver_id = ?", filters["approver_id"])
+		}
+		return q
+	}
+
+	// Spend by project.
+	type spendRow struct {
+		Code   string
+		Name   string
+		Amount float64
+	}
+	var projectRows []spendRow
+	baseApproved().
+		Select("er.project AS code, COALESCE(p.DESCRIPTION, er.project) AS name, SUM(er.amount) AS amount").
+		Joins("LEFT JOIN projects p ON p.CODE = er.project").
+		Group("er.project, p.DESCRIPTION").
+		Order("amount DESC").
+		Limit(10).
+		Scan(&projectRows)
+	for _, row := range projectRows {
+		result.SpendByProject = append(result.SpendByProject, dtos.AnalyticsSpendItem{
+			Name: row.Name, Code: row.Code, Amount: row.Amount,
+		})
+	}
+
+	// Spend by GL account.
+	var glRows []spendRow
+	baseApproved().
+		Select("er.gl_account AS code, COALESCE(ga.DESCRIPTION, er.gl_account) AS name, SUM(er.amount) AS amount").
+		Joins("LEFT JOIN gl_accs ga ON ga.DOCKEY = er.gl_account").
+		Group("er.gl_account, ga.DESCRIPTION").
+		Order("amount DESC").
+		Limit(10).
+		Scan(&glRows)
+	for _, row := range glRows {
+		result.SpendByGL = append(result.SpendByGL, dtos.AnalyticsSpendItem{
+			Name: row.Name, Code: row.Code, Amount: row.Amount,
+		})
+	}
+
+	// Spend by payment method.
+	var pmRows []spendRow
+	baseApproved().
+		Select("er.payment_method AS code, COALESCE(pm.DESCRIPTION, er.payment_method) AS name, SUM(er.amount) AS amount").
+		Joins("LEFT JOIN payment_methods pm ON pm.CODE = er.payment_method").
+		Group("er.payment_method, pm.DESCRIPTION").
+		Order("amount DESC").
+		Scan(&pmRows)
+	for _, row := range pmRows {
+		result.SpendByPayment = append(result.SpendByPayment, dtos.AnalyticsSpendItem{
+			Name: row.Name, Code: row.Code, Amount: row.Amount,
+		})
+	}
+
+	// Top submitters (by approved spend).
+	type lbRow struct {
+		ID     uint
+		Name   string
+		Team   string
+		Amount float64
+		Count  int
+	}
+	var submitterRows []lbRow
+	baseApproved().
+		Select("u.id AS id, u.name AS name, COALESCE(d.name, '') AS team, SUM(er.amount) AS amount, COUNT(er.id) AS count").
+		Joins("JOIN users u ON u.id = er.user_id").
+		Joins("LEFT JOIN departments d ON d.id = u.department_id").
+		Group("u.id, u.name, d.name").
+		Order("amount DESC").
+		Limit(10).
+		Scan(&submitterRows)
+	for _, row := range submitterRows {
+		result.TopSubmitters = append(result.TopSubmitters, dtos.AnalyticsLeaderboardItem{
+			ID: row.ID, Name: row.Name, Team: row.Team, Amount: row.Amount, Count: row.Count,
+		})
+	}
+
+	// Top approvers (by approved amount across their approvals).
+	approversQ := r.db.Table("expense_approvals ea").
+		Select("u.id AS id, u.name AS name, COALESCE(d.name, '') AS team, SUM(er.amount) AS amount, COUNT(ea.id) AS count").
+		Joins("JOIN users u ON u.id = ea.approver_id").
+		Joins("LEFT JOIN departments d ON d.id = u.department_id").
+		Joins("JOIN expense_requests er ON er.id = ea.request_id").
+		Where("ea.status = 'approved'")
+	if filters["start_date"] != nil && filters["end_date"] != nil {
+		approversQ = approversQ.Where("DATE(er.date_submitted) BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
+	}
+	if filters["user_id"] != nil {
+		approversQ = approversQ.Where("er.user_id = ?", filters["user_id"])
+	}
+	var approverRows []lbRow
+	approversQ.
+		Group("u.id, u.name, d.name").
+		Order("amount DESC").
+		Limit(10).
+		Scan(&approverRows)
+	for _, row := range approverRows {
+		result.TopApprovers = append(result.TopApprovers, dtos.AnalyticsLeaderboardItem{
+			ID: row.ID, Name: row.Name, Team: row.Team, Amount: row.Amount, Count: row.Count,
+		})
+	}
+
+	// Recent activity: merge latest submissions + latest approval actions.
+	type activityEvent struct {
+		Kind   string
+		Who    string
+		Code   string
+		Text   string
+		Amount float64
+		At     time.Time
+	}
+	var events []activityEvent
+
+	// Recent expense request submissions.
+	type submissionRow struct {
+		ID            uint
+		Amount        float64
+		SubmitterName string
+		DateSubmitted time.Time
+		Status        string
+	}
+	var submissions []submissionRow
+	submissionQ := r.db.Table("expense_requests er").
+		Select("er.id, er.amount, u.name AS submitter_name, er.date_submitted, er.status").
+		Joins("JOIN users u ON u.id = er.user_id").
+		Order("er.date_submitted DESC").
+		Limit(20)
+	if filters["start_date"] != nil && filters["end_date"] != nil {
+		submissionQ = submissionQ.Where("DATE(er.date_submitted) BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
+	}
+	if filters["user_id"] != nil {
+		submissionQ = submissionQ.Where("er.user_id = ?", filters["user_id"])
+	}
+	if filters["approver_id"] != nil {
+		submissionQ = submissionQ.
+			Joins("JOIN expense_approvals _sa ON _sa.request_id = er.id AND _sa.approver_id = ?", filters["approver_id"])
+	}
+	submissionQ.Scan(&submissions)
+	for _, s := range submissions {
+		kind := s.Status
+		text := "submitted"
+		if s.Status == "approved" {
+			text = "submitted (approved)"
+		} else if s.Status == "rejected" {
+			text = "submitted (rejected)"
+		}
+		events = append(events, activityEvent{
+			Kind:   kind,
+			Who:    s.SubmitterName,
+			Code:   fmt.Sprintf("EXP-%05d", s.ID),
+			Text:   text,
+			Amount: s.Amount,
+			At:     s.DateSubmitted,
+		})
+	}
+
+	// Recent approval actions.
+	type approvalActionRow struct {
+		RequestID    uint
+		Amount       float64
+		ApproverName string
+		ApprovalDate time.Time
+		Status       string
+	}
+	var approvalActions []approvalActionRow
+	approvalActionsQ := r.db.Table("expense_approvals ea").
+		Select("ea.request_id, er.amount, u.name AS approver_name, ea.approval_date, ea.status").
+		Joins("JOIN users u ON u.id = ea.approver_id").
+		Joins("JOIN expense_requests er ON er.id = ea.request_id").
+		Where("ea.status IN ('approved', 'rejected') AND ea.approval_date IS NOT NULL").
+		Order("ea.approval_date DESC").
+		Limit(20)
+	if filters["start_date"] != nil && filters["end_date"] != nil {
+		approvalActionsQ = approvalActionsQ.Where("DATE(er.date_submitted) BETWEEN ? AND ?", filters["start_date"], filters["end_date"])
+	}
+	if filters["user_id"] != nil {
+		approvalActionsQ = approvalActionsQ.Where("er.user_id = ?", filters["user_id"])
+	}
+	if filters["approver_id"] != nil {
+		approvalActionsQ = approvalActionsQ.Where("ea.approver_id = ?", filters["approver_id"])
+	}
+	approvalActionsQ.Scan(&approvalActions)
+	for _, a := range approvalActions {
+		text := "approved"
+		if a.Status == "rejected" {
+			text = "rejected"
+		}
+		events = append(events, activityEvent{
+			Kind:   a.Status,
+			Who:    a.ApproverName,
+			Code:   fmt.Sprintf("EXP-%05d", a.RequestID),
+			Text:   text,
+			Amount: a.Amount,
+			At:     a.ApprovalDate,
+		})
+	}
+
+	// Sort all events by time DESC, deduplicate by Code+Kind, take top 15.
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].At.After(events[j].At)
+	})
+	seen := make(map[string]bool)
+	for _, ev := range events {
+		key := ev.Code + ev.Kind
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result.RecentActivity = append(result.RecentActivity, dtos.AnalyticsActivityItem{
+			Kind:   ev.Kind,
+			Who:    ev.Who,
+			Code:   ev.Code,
+			Text:   ev.Text,
+			Amount: ev.Amount,
+			When:   humanizeTime(ev.At),
+		})
+		if len(result.RecentActivity) >= 15 {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func humanizeTime(t time.Time) string {
+	diff := time.Since(t)
+	switch {
+	case diff < time.Minute:
+		return "just now"
+	case diff < time.Hour:
+		mins := int(diff.Minutes())
+		if mins == 1 {
+			return "1 min ago"
+		}
+		return fmt.Sprintf("%d min ago", mins)
+	case diff < 24*time.Hour:
+		hrs := int(diff.Hours())
+		if hrs == 1 {
+			return "1 hr ago"
+		}
+		return fmt.Sprintf("%d hr ago", hrs)
+	default:
+		days := int(diff.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
 }

--- a/routes/Routes.go
+++ b/routes/Routes.go
@@ -130,6 +130,7 @@ func initExpenseRequestsRoutes(e *echo.Group, db *gorm.DB, firebaseApp *firebase
 	e.GET("/expense-requests/user/:id", expenseRequestsController.GetExpenseRequestsByUserID, middlewares.IsAuthenticated)
 	e.GET("/expense-requests/approver/:id", expenseRequestsController.GetExpenseRequestByApproverID, middlewares.IsAuthenticated)
 	e.GET("/expense-requests/summary", expenseRequestsController.GetExpenseRequestsSummary, middlewares.IsAuthenticated)
+	e.GET("/expense-requests/analytics", expenseRequestsController.GetAnalytics, middlewares.IsAuthenticated)
 	e.POST("/expense-requests/:id/send-to-sqlacc", expenseRequestsController.SendExpenseRequestToSQLACC, middlewares.IsAuthenticated, middlewares.RequirePermission(db, "expense-request", "send-to-sqlacc"))
 	e.DELETE("/expense-requests/:id", expenseRequestsController.DeleteExpenseRequest, middlewares.IsAuthenticated)
 	e.GET("/expense-requests/attachment/:filename", expenseRequestsController.ServeExpenseRequestAttachment)

--- a/services/ExpenseRequestsService.go
+++ b/services/ExpenseRequestsService.go
@@ -37,6 +37,10 @@ func (s *ExpenseRequestsService) GetExpenseRequestsSummary(filters map[string]an
 	return s.ExpenseRequestsRepo.GetExpenseRequestsSummary(filters)
 }
 
+func (s *ExpenseRequestsService) GetAnalytics(filters map[string]any) (dtos.AnalyticsResponse, error) {
+	return s.ExpenseRequestsRepo.GetAnalytics(filters)
+}
+
 func (s *ExpenseRequestsService) CreateExpenseRequest(expenseRequest *models.ExpenseRequests) error {
 	return s.ExpenseRequestsRepo.CreateExpenseRequest(expenseRequest)
 }


### PR DESCRIPTION
Introduces GET /expense-requests/analytics returning spend by project, GL account, and payment method; top submitters and approvers leaderboards; and a deduplicated recent activity feed — all filtered by date range, user_id, or approver_id.

Also fixes the summary endpoint: daily totals now track approved/pending/ rejected amounts separately via a new DailyBreakdown DTO, and the date filter uses DATE() to correctly include records submitted on the end date. Fixes GL account join using the correct table name (gl_accs).